### PR TITLE
Add optional serde1 feature for serializing/deserializing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ categories = ["algorithms", "no-std"]
 
 [dependencies]
 rand_core = "0.6"
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"
+serde_test = "1.0"
+
+[features]
+default = []
+serde1 = ["serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@ use core::fmt::Debug;
 
 use rand_core::{impls::fill_bytes_via_next, Error, RngCore, SeedableRng};
 
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
+
 /// An instance of the [WyRand](https://github.com/wangyi-fudan/wyhash) random number generator.
 ///
 /// While not cryptographically secure, WyRand is solid enough to pass
@@ -106,6 +109,7 @@ use rand_core::{impls::fill_bytes_via_next, Error, RngCore, SeedableRng};
 /// println!("Random string: {rand_string}")
 /// ```
 #[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct WyRand {
 	seed: u64,
 }
@@ -174,5 +178,26 @@ mod tests {
 		let rng = WyRand::from_seed(Default::default());
 
 		assert_eq!(format!("{:?}", rng), "WyRand");
+	}
+
+	#[cfg(feature = "serde1")]
+	#[test]
+	fn serde_tokens() {
+		use serde_test::{assert_tokens, Token};
+
+		let rng = WyRand::seed_from_u64(12345);
+
+		assert_tokens(
+			&rng,
+			&[
+				Token::Struct {
+					name: "WyRand",
+					len: 1,
+				},
+				Token::BorrowedStr("seed"),
+				Token::U64(12345),
+				Token::StructEnd,
+			],
+		);
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,17 +187,14 @@ mod tests {
 
 		let rng = WyRand::seed_from_u64(12345);
 
-		assert_tokens(
-			&rng,
-			&[
-				Token::Struct {
-					name: "WyRand",
-					len: 1,
-				},
-				Token::BorrowedStr("seed"),
-				Token::U64(12345),
-				Token::StructEnd,
-			],
-		);
+		assert_tokens(&rng, &[
+			Token::Struct {
+				name: "WyRand",
+				len: 1,
+			},
+			Token::BorrowedStr("seed"),
+			Token::U64(12345),
+			Token::StructEnd,
+		]);
 	}
 }


### PR DESCRIPTION
`rand`'s various PRNGs all offer optional serialization/deserialization implementations behind a `serde1` feature flag. Therefore, I thought I'd add it here as well, so to unlock some use-cases I'd like to enable for game-dev purposes. Also added a test to confirm that serde is generating the correct tokens for the given struct, which will confirm what to expect from serialised output in a way that does not depend on any given format.