### PR TITLE
Increment version of crate for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rand-wyrand"
 description = "The extremely fast WyRand PRNG for the rand ecosystem of crates."
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Lucy <lucy@absolucy.moe>"]
 repository = "https://github.com/Absolucy/rand-wyrand"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
With the changes made to the crate, it would be nice for a new version to be released. However, given changes to the `Debug` output, it is a breaking change so I've incremented it to be a `0.2` version.